### PR TITLE
Add redirect to my SwitchGuide

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,12 @@
 </head>
 
 <body>
+  <script type="text/javascript">
+    window.onload() = function() {
+      // Simulate an HTTP redirect:
+      window.location.replace("https://noirscape.github.io/SwitchGuide/");
+    }
+  </script>  
   <div class="container-content container-fluid">
     <div class="row">
       <div class="col-lg-3"></div>


### PR DESCRIPTION
This redirects your guide to mine. 

As people still seem to be using yours, and by your own admission, you're not updating it anymore (therefore making it oudated), this would mean that anyone visiting your guide would probably be better off visiting mine, particularly since your guide still references NH for support, but it's not a supported guide by NH anymore.

It's a javascript redirect if you're curious about the how.